### PR TITLE
Add deck and note options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,35 @@ interface. Anki also is happier if you avoid having two notes with the same `sor
 necessary. By default, the `sort_field` is the first field, but you can change it by passing `sort_field=` to `Note()`
 or implementing `sort_field` as a property in a subclass (similar to `guid`).
 
+## Deck and Note Options
+`Deck`s and `Note`s have options, many of which influence the Anki SRS algorithm. These can change when and how often cards are due, how leech cards are handled, how cards transition between SRS stages, and more.
+
+Deck options are primarily provided through the `OptionGroup` which is closely modeled after the Anki deck options window. In addition, the `Deck` has `description` and `creation_time` attributes. Note that Anki defines card due dates relative to deck creation time.
+
+``` python
+options = genanki.OptionsGroup()
+options.autoplay_audio = False
+options.new_cards_per_day = 10
+options.max_reviews_per_day = 200
+options.review_bury_related_cards = False
+options.interval_modifier = 0.85
+my_deck = genanki.Deck(
+  2059400110,
+  'Country Capitals',
+  options=options)
+my_deck.description = r'The capitals of the 100 most populous countries. \nCreated on {}.'.format(deck.creation_time.date().isoformat())
+```
+
+`Note` options typically vary significantly across notes and are thus set directly in the note.
+
+``` python
+my_note.stage = 1     # SRS learning stage: 0 = new, 1 = learning, 2 = review.
+my_note.interval = 20 # Days between next review and the one following.
+```
+
+Decks and notes have more options which are documented in `genanki/__init__.py`. For full details on their meaning and relation to the Anki SRS algorithm, please see the [official Anki documentation](https://apps.ankiweb.net/docs/manual.html#what-spaced-repetition-algorithm-does-anki-use).
+
+
 ## YAML for Templates (and Fields)
 You can create your template definitions in the YAML format and pass them as a `str` to `Model()`. You can also do this
 for fields.

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -315,7 +315,7 @@ class Deck:
     self.notes = []
     self.models = {}  # map of model id to model
     self.description = ''
-    self.options = options if options else OptionsGroup()
+    self.options = options or OptionsGroup()
     self.creation_time = datetime.now()
 
   def add_note(self, note):

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -164,12 +164,12 @@ class Card:
         note_id,    # nid - note ID
         deck_id,    # did - deck ID
         self.ord,   # ord - which card template it corresponds to
-        now_ts,     # mod - modification time as epoch seconds
+        now_ts,     # mod - modification time as seconds since Unix epoch
         -1,         # usn - value of -1 indicates need to push to server
         stage,      # type - 0=new, 1=learning, 2=review
         stage,      # queue - same as type unless buried
         due,        # due - new: unused
-                    #       learning: due time as integer seconds since epoch
+                    #       learning: due time as integer seconds since Unix epoch
                     #       review: integer days relative to deck creation
         interval,   # ivl - positive days, negative seconds
         ease,       # factor - integer ease factor used by SRS, 2500 = 250%
@@ -195,10 +195,24 @@ class Note:
       # guid was defined as a property
       pass
 
+    ## Options ##
+
+    """SRS learning stage.
+    0 = new, 1 = learning, 2 = review."""
     self.stage = 0
+    """Behavior depends on learning stage of note.
+       new: unused.
+       learning: due time as integer seconds since Unix epoch.
+       review: integer days relative to deck creation timestamp."""
     self.due = 0
+    """Time between next review and the one following.
+    Positive values are in days, negative in seconds."""
     self.interval = 0
+    """Integer 'ease' factor used by SRS algorithm.
+    Example: 2500 = 250%."""
     self.ease = 0
+    """Repititions remaining until graduation from the learning stage.
+    Unused during other SRS stages."""
     self.reps_til_grad = 0
 
   @property
@@ -261,26 +275,27 @@ class OptionsGroup:
   def __init__(self, options_id=None, name=None):
     self.options_id = options_id
     self.options_group_name = name
-    #   General.
-    self.max_time_per_answer = 60
+    # Organized according to options window tabs in Anki.
+    ## General ##
+    self.max_time_per_answer = 60 # minutes
     self.show_timer = False
     self.autoplay_audio = True
     self.replay_audio_for_answer = True
-    #   New.
-    self.new_steps = [1, 10]
-    self.order = 1
-    self.new_cards_per_day = 20
-    self.graduating_interval = 1
-    self.easy_interval = 4
-    self.starting_ease = 2500
-    self.new_bury_related_cards = True
-    #   Reviews.
+    ## New Cards ##
+    self.new_steps = [1, 10]     # list of minute intervals per learning stage
+    self.order = 1               # option selected in dropdown (0 = first, 1 = second)
+    self.new_cards_per_day = 20  # days
+    self.graduating_interval = 1 # days
+    self.easy_interval = 4       # days
+    self.starting_ease = 2500    # 2500 = 250%
+    self.bury_related_new_cards = True
+    ## Reviews ##
     self.max_reviews_per_day = 100
     self.easy_bonus = 1.3
-    self.interval_modifier = 1
-    self.max_interval = 36500
-    self.review_bury_related_cards = True
-    #   Lapses.
+    self.interval_modifier = 1.0
+    self.max_interval = 36500 # days
+    self.bury_related_review_cards = True
+    ## Lapses ##
     self.lapse_steps = [10]
     self.leech_interval_multiplier = 0
     self.lapse_min_interval = 1
@@ -312,11 +327,11 @@ class Deck:
   def __init__(self, deck_id=None, name=None, options=None):
     self.deck_id = deck_id
     self.name = name
+    self.description = ''
+    self.creation_time = datetime.now()
     self.notes = []
     self.models = {}  # map of model id to model
-    self.description = ''
     self.options = options or OptionsGroup()
-    self.creation_time = datetime.now()
 
   def add_note(self, note):
     self.notes.append(note)

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -332,8 +332,8 @@ class Deck:
     params = self.options._format_fields()
 
     params.update({
-      'creation_time': self.creation_time.timestamp(),
-      'modification_time': self.creation_time.timestamp() * 1000,
+      'creation_time': int(self.creation_time.timestamp()),
+      'modification_time': int(self.creation_time.timestamp()) * 1000,
       'name': self.name,
       'deck_id': self.deck_id,
       'models': json.dumps(models),

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -163,7 +163,7 @@ class Card:
     cursor.execute('INSERT INTO cards VALUES(null,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
         note_id,    # nid - note ID
         deck_id,    # did - deck ID
-        self.ord,   # ord - which card template it corresponds
+        self.ord,   # ord - which card template it corresponds to
         now_ts,     # mod - modification time as epoch seconds
         -1,         # usn - value of -1 indicates need to push to server
         level,      # type - 0=new, 1=learning, 2=review
@@ -258,7 +258,7 @@ class Note:
 
 
 class OptionsGroup:
-  def __init__(self, options_id=1, name='Default'):
+  def __init__(self, options_id=None, name=None):
     self.options_id = options_id
     self.options_group_name = name
     #   General.
@@ -269,7 +269,7 @@ class OptionsGroup:
     #   New.
     self.new_steps = [1, 10]
     self.order = 1
-    self.new_cardsperday = 20
+    self.new_cards_per_day = 20
     self.graduating_interval = 1
     self.easy_interval = 4
     self.starting_ease = 2500
@@ -315,7 +315,7 @@ class Deck:
     self.notes = []
     self.models = {}  # map of model id to model
     self.description = ''
-    self.options = options
+    self.options = options if options else OptionsGroup()
     self.creation_time = datetime.now()
 
   def add_note(self, note):

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -159,15 +159,15 @@ class Card:
     self.interval = 0
 
   def write_to_db(self, cursor, now_ts, deck_id, note_id,
-                  level, due, interval, ease, reps_til_grad):
+                  stage, due, interval, ease, reps_til_grad):
     cursor.execute('INSERT INTO cards VALUES(null,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
         note_id,    # nid - note ID
         deck_id,    # did - deck ID
         self.ord,   # ord - which card template it corresponds to
         now_ts,     # mod - modification time as epoch seconds
         -1,         # usn - value of -1 indicates need to push to server
-        level,      # type - 0=new, 1=learning, 2=review
-        level,      # queue - same as type unless buried
+        stage,      # type - 0=new, 1=learning, 2=review
+        stage,      # queue - same as type unless buried
         due,        # due - new: unused
                     #       learning: due time as integer seconds since epoch
                     #       review: integer days relative to deck creation
@@ -195,10 +195,10 @@ class Note:
       # guid was defined as a property
       pass
 
-    self.level = 0
+    self.stage = 0
     self.due = 0
     self.interval = 0
-    self.ease = 1000
+    self.ease = 0
     self.reps_til_grad = 0
 
   @property
@@ -247,7 +247,7 @@ class Note:
     note_id = cursor.lastrowid
     for card in self.cards:
       card.write_to_db(cursor, now_ts, deck_id, note_id,
-                       self.level, self.due, self.interval,
+                       self.stage, self.due, self.interval,
                        self.ease, self.reps_til_grad)
 
   def _format_fields(self):

--- a/genanki/apkg_col.py
+++ b/genanki/apkg_col.py
@@ -1,9 +1,9 @@
 APKG_COL = r'''
 INSERT INTO col VALUES(
     null,
-    1411124400,
-    1425279151694,
-    1425279151690,
+    :creation_time,
+    :modification_time,
+    :modification_time,
     11,
     0,
     0,
@@ -15,7 +15,7 @@ INSERT INTO col VALUES(
         "addToCur": true,
         "collapseTime": 1200,
         "curDeck": 1,
-        "curModel": "1425279151691",
+        "curModel": "' || :modification_time || '",
         "dueCounts": true,
         "estTimes": true,
         "newBury": true,

--- a/genanki/apkg_col.py
+++ b/genanki/apkg_col.py
@@ -25,7 +25,7 @@ INSERT INTO col VALUES(
         "sortType": "noteFld",
         "timeLim": 0
     }',
-    ?3,
+    :models,
     '{
         "1": {
             "collapsed": false,
@@ -55,78 +55,73 @@ INSERT INTO col VALUES(
             ],
             "usn": 0
         },
-        "' || ?2 || '": {
+        "' || :deck_id || '": {
             "collapsed": false,
-            "conf": 1,
-            "desc": "",
+            "conf": ' || :options_id || ',
+            "desc": "' || :description || '",
             "dyn": 0,
-            "extendNew": 0,
+            "extendNew": 10,
             "extendRev": 50,
-            "id": ' || ?2 || ',
+            "id": ' || :deck_id || ',
             "lrnToday": [
-                163,
-                2
+                5,
+                0
             ],
             "mod": 1425278051,
-            "name": "' || ?1 || '",
+            "name": "' || :name || '",
             "newToday": [
-                163,
-                2
+                5,
+                0
             ],
             "revToday": [
-                163,
+                5,
                 0
             ],
             "timeToday": [
-                163,
-                23598
+                5,
+                0
             ],
             "usn": -1
         }
     }',
     '{
-        "1": {
-            "autoplay": true,
-            "id": 1,
+        "' || :options_id || '": {
+            "autoplay": ' || :autoplay_audio || ',
+            "id": ' || :options_id || ',
             "lapse": {
-                "delays": [
-                    10
-                ],
-                "leechAction": 0,
-                "leechFails": 8,
-                "minInt": 1,
-                "mult": 0
+                "delays": ' || :lapse_steps || ',
+                "leechAction": ' || :leech_action || ',
+                "leechFails": ' || :leech_threshold || ',
+                "minInt": ' || :lapse_min_interval || ',
+                "mult": ' || :leech_interval_multiplier || '
             },
-            "maxTaken": 60,
+            "maxTaken": ' || :max_time_per_answer || ',
             "mod": 0,
-            "name": "Default",
+            "name": "' || :options_group_name || '",
             "new": {
-                "bury": true,
-                "delays": [
-                    1,
-                    10
-                ],
-                "initialFactor": 2500,
+                "bury": ' || :new_bury_related_cards || ',
+                "delays": ' || :new_steps || ',
+                "initialFactor": ' || :starting_ease || ',
                 "ints": [
-                    1,
-                    4,
+                    ' || :graduating_interval || ',
+                    ' || :easy_interval || ',
                     7
                 ],
-                "order": 1,
-                "perDay": 20,
+                "order": ' || :order || ',
+                "perDay": ' || :new_cardsperday || ',
                 "separate": true
             },
-            "replayq": true,
+            "replayq": ' || :replay_audio_for_answer || ',
             "rev": {
-                "bury": true,
-                "ease4": 1.3,
+                "bury": ' || :review_bury_related_cards || ',
+                "ease4": ' || :easy_bonus || ',
                 "fuzz": 0.05,
-                "ivlFct": 1,
-                "maxIvl": 36500,
+                "ivlFct": ' || :interval_modifier || ',
+                "maxIvl": ' || :max_interval || ',
                 "minSpace": 1,
-                "perDay": 100
+                "perDay": ' || :max_reviews_per_day || '
             },
-            "timer": 0,
+            "timer": ' || :show_timer || ',
             "usn": 0
         }
     }',

--- a/genanki/apkg_col.py
+++ b/genanki/apkg_col.py
@@ -86,8 +86,8 @@ INSERT INTO col VALUES(
     }',
     '{
         "' || :options_id || '": {
-            "autoplay": ' || :autoplay_audio || ',
             "id": ' || :options_id || ',
+            "autoplay": ' || :autoplay_audio || ',
             "lapse": {
                 "delays": ' || :lapse_steps || ',
                 "leechAction": ' || :leech_action || ',
@@ -108,7 +108,7 @@ INSERT INTO col VALUES(
                     7
                 ],
                 "order": ' || :order || ',
-                "perDay": ' || :new_cardsperday || ',
+                "perDay": ' || :new_cards_per_day || ',
                 "separate": true
             },
             "replayq": ' || :replay_audio_for_answer || ',


### PR DESCRIPTION
Adds options to decks and notes.

* Most deck options are handled in a new `OptionsGroup` class which allows multiple decks to share options, reflecting Anki's very similar option groups. OptionsGroup is closely modeled after the deck options window in Anki.
* Decks now have a `description` and `creation_time`. The latter is important since card due dates are defined relative to deck creation time.
* Notes now have a few option attributes, all related to SRS in some way (due date, interval, etc.).
* Add some initial README documentation.
* Add more internal documentation about database fields 
* Add internal documentation about options.
* No tests yet.
* `akpg_col.py` now has field substitution by dict rather than array. This was necessary due to the large number of options needing to be inserted. I didn't use `format` though!

I tried to stick to the coding style that already existed. Hopefully my blasphemies were kept at a minimum. X-D