### PR TITLE
fix card order and date of creation bug  :

### DIFF
--- a/genanki/card.py
+++ b/genanki/card.py
@@ -1,3 +1,7 @@
+# Using the epoch milliseconds of when the Card was created as ANKI do
+import time
+current_milli_time = lambda: int(round(time.time() * 1000))
+
 class Card:
   def __init__(self, ord, suspend=False):
     self.ord = ord
@@ -5,7 +9,11 @@ class Card:
 
   def write_to_db(self, cursor, now_ts, deck_id, note_id):
     queue = -1 if self.suspend else 0
-    cursor.execute('INSERT INTO cards VALUES(null,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
+    card_id = current_milli_time()
+    # Wait for 1 milliseconds to ensure that id is unique
+    time.sleep(.001)
+    cursor.execute('INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
+        card_id,     # id
         note_id,    # nid
         deck_id,    # did
         self.ord,   # ord


### PR DESCRIPTION
modified the way to generate note and card id
i replaced it by the way that anki create ids  :  "the epoch milliseconds of when the Card / Note was created" 
this is a solution to an issue that i remarked [here](https://github.com/kerrickstaley/genanki/issues/29)