### PR TITLE
Allow passing full paths to media files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,18 @@ To add sounds or images, set the `media_files` attribute on your `Package`:
 
 ```python
 my_package = genanki.Package(my_deck)
-my_package.media_files = ['sound.mp3', 'image.jpg']
+my_package.media_files = ['sound.mp3', 'images/image.jpg']
 ```
 
-The media files should be in the current working directory. They can be referenced in notes like this:
+`media_files` should have the path (relative or absolute) to each file. They can be referenced in notes like this:
 
 ```html
 [sound:sound.mp3]
 <img src="image.jpg">
 ```
+
+You should only put the filename (aka basename) and not the full path in the `src` attribute. Media files should have
+unique filenames.
 
 ## Note GUIDs
 `Note`s have a `guid` property that uniquely identifies the note. If you import a new note that has the same GUID as an

--- a/genanki/package.py
+++ b/genanki/package.py
@@ -34,11 +34,12 @@ class Package:
     with zipfile.ZipFile(file, 'w') as outzip:
       outzip.write(dbfilename, 'collection.anki2')
 
-      media_json = dict(enumerate(self.media_files))
+      media_file_idx_to_path = dict(enumerate(self.media_files))
+      media_json = {idx: os.path.basename(path) for idx, path in media_file_idx_to_path.items()}
       outzip.writestr('media', json.dumps(media_json))
 
-      for i, f in media_json.items():
-        outzip.write(f, str(i))
+      for idx, path in media_file_idx_to_path.items():
+        outzip.write(path, str(idx))
 
   def write_to_db(self, cursor, now_ts):
     cursor.executescript(APKG_SCHEMA)

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -225,7 +225,9 @@ class TestWithCollection:
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_media_files_absolute_paths(self):
-    tmpdir = tempfile.mkdtemp()
+    # change to a scratch directory so we can write files
+    os.chdir(tempfile.mkdtemp())
+    media_dir = tempfile.mkdtemp()
 
     deck = genanki.Deck(123456, 'foodeck')
     note = genanki.Note(TEST_MODEL, [
@@ -234,8 +236,8 @@ class TestWithCollection:
     deck.add_note(note)
 
     # populate files with data
-    present_mp3_path = os.path.join(tmpdir, 'present.mp3')
-    present_jpg_path = os.path.join(tmpdir, 'present.jpg')
+    present_mp3_path = os.path.join(media_dir, 'present.mp3')
+    present_jpg_path = os.path.join(media_dir, 'present.jpg')
     with open(present_mp3_path, 'wb') as h:
       h.write(VALID_MP3)
     with open(present_jpg_path, 'wb') as h:

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -103,6 +103,15 @@ class TestWithCollection:
     importer = anki.importing.apkg.AnkiPackageImporter(self.col, outf.name)
     importer.run()
 
+  def check_media(self):
+    # col.media.check seems to assume that the cwd is the media directory. So this helper function
+    # chdirs to the media dir before running check and then goes back to the original cwd.
+    orig_cwd = os.getcwd()
+    os.chdir(self.col.media.dir())
+    ret = self.col.media.check()
+    os.chdir(orig_cwd)
+    return ret
+
   def test_generated_deck_can_be_imported(self):
     deck = genanki.Deck(123456, 'foodeck')
     note = genanki.Note(TEST_MODEL, ['a', 'b'])
@@ -224,7 +233,7 @@ class TestWithCollection:
     os.remove('present.mp3')
     os.remove('present.jpg')
 
-    missing, unused, invalid = self.col.media.check()
+    missing, unused, invalid = self.check_media()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_media_files_absolute_paths(self):
@@ -248,7 +257,7 @@ class TestWithCollection:
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
 
-    missing, unused, invalid = self.col.media.check()
+    missing, unused, invalid = self.check_media()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_write_deck_without_deck_id_fails(self):

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -221,6 +221,9 @@ class TestWithCollection:
 
     self.import_package(genanki.Package(deck, media_files=['present.mp3', 'present.jpg']))
 
+    os.remove('present.mp3')
+    os.remove('present.jpg')
+
     missing, unused, invalid = self.col.media.check()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -224,6 +224,28 @@ class TestWithCollection:
     missing, unused, invalid = self.col.media.check()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
+  def test_media_files_absolute_paths(self):
+    tmpdir = tempfile.mkdtemp()
+
+    deck = genanki.Deck(123456, 'foodeck')
+    note = genanki.Note(TEST_MODEL, [
+      'question [sound:present.mp3] [sound:missing.mp3]',
+      'answer <img src="present.jpg"> <img src="missing.jpg">'])
+    deck.add_note(note)
+
+    # populate files with data
+    present_mp3_path = os.path.join(tmpdir, 'present.mp3')
+    present_jpg_path = os.path.join(tmpdir, 'present.jpg')
+    with open(present_mp3_path, 'wb') as h:
+      h.write(VALID_MP3)
+    with open(present_jpg_path, 'wb') as h:
+      h.write(VALID_JPG)
+
+    self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
+
+    missing, unused, invalid = self.col.media.check()
+    assert set(missing) == {'missing.mp3', 'missing.jpg'}
+
   def test_write_deck_without_deck_id_fails(self):
     # change to a scratch directory so we can write files
     os.chdir(tempfile.mkdtemp())


### PR DESCRIPTION
Allow passing full path to media files, rather than requiring media files to be in the CWD.

This change also fixes a bug in the unit tests: `self.col.media.check()` assumes that the media directory is the CWD, and so tests would fail or succeed based on the files in the CWD rather than what media files are actually in the package. We fix this by chdir'ing to `self.col.media.dir()` each time before running `self.col.media.check()`.