### PR TITLE
Allow setting sort_field from model

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ my_model = genanki.Model(
     {'name': 'Question'},
     {'name': 'Answer'},
   ],
+  sort_field_number=2,
   templates=[
     {
       'name': 'Card 1',
@@ -47,6 +48,12 @@ CSS.
 You need to pass a `model_id` so that Anki can keep track of your model. It's important that you use a unique `model_id`
 for each `Model` you define. Use `import random; random.randrange(1 << 30, 1 << 31)` to generate a suitable model_id, and hardcode it
 into your `Model` definition.
+
+Finally, the notes browser inside Anki will sort cards with a special sorting field. The default value for this field
+is the value of the note's first field. You can change the used note field by passing a number to the
+`sort_field_number` argument when creating the `Model` (`2` for second field).
+In case some of your notes need to use a sorting key that you would rather not be present in the note fields,
+then you can pass the sorting key value with the `sort_field` argument when creating your `Note`.
 
 ## Generating a Deck/Package
 To import your notes into Anki, you need to add them to a `Deck`:
@@ -121,12 +128,6 @@ class MyNote(genanki.Note):
   def guid(self):
     return genanki.guid_for(self.fields[0], self.fields[1])
 ```
-
-## sort_field
-Anki has a value for each `Note` called the `sort_field`. Anki uses this value to sort the cards in the Browse
-interface. Anki also is happier if you avoid having two notes with the same `sort_field`, although this isn't strictly
-necessary. By default, the `sort_field` is the first field, but you can change it by passing `sort_field=` to `Note()`
-or implementing `sort_field` as a property in a subclass (similar to `guid`).
 
 ## YAML for Templates (and Fields)
 You can create your template definitions in the YAML format and pass them as a `str` to `Model()`. You can also do this

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ my_model = genanki.Model(
     {'name': 'Question'},
     {'name': 'Answer'},
   ],
-  sort_field_number=2,
   templates=[
     {
       'name': 'Card 1',
@@ -48,12 +47,6 @@ CSS.
 You need to pass a `model_id` so that Anki can keep track of your model. It's important that you use a unique `model_id`
 for each `Model` you define. Use `import random; random.randrange(1 << 30, 1 << 31)` to generate a suitable model_id, and hardcode it
 into your `Model` definition.
-
-Finally, the notes browser inside Anki will sort cards with a special sorting field. The default value for this field
-is the value of the note's first field. You can change the used note field by passing a number to the
-`sort_field_number` argument when creating the `Model` (`2` for second field).
-In case some of your notes need to use a sorting key that you would rather not be present in the note fields,
-then you can pass the sorting key value with the `sort_field` argument when creating your `Note`.
 
 ## Generating a Deck/Package
 To import your notes into Anki, you need to add them to a `Deck`:
@@ -128,6 +121,14 @@ class MyNote(genanki.Note):
   def guid(self):
     return genanki.guid_for(self.fields[0], self.fields[1])
 ```
+
+## sort_field
+Anki has a value for each `Note` called the `sort_field`. Anki uses this value to sort the cards in the Browse
+interface. Anki also is happier if you avoid having two notes with the same `sort_field`, although this isn't strictly
+necessary. By default, the `sort_field` is the first field, but you can change it by passing `sort_field=` to `Note()`
+or implementing `sort_field` as a property in a subclass (similar to `guid`).
+
+You can also pass `sort_field_index=` to `Model()` to change the sort field. `0` means the first field in the Note, `1` means the second, etc.
 
 ## YAML for Templates (and Fields)
 You can create your template definitions in the YAML format and pass them as a `str` to `Model()`. You can also do this

--- a/genanki/model.py
+++ b/genanki/model.py
@@ -12,7 +12,7 @@ class Model:
                        + '\\begin{document}\n')
   DEFAULT_LATEX_POST = '\\end{document}'
 
-  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_index=1,
+  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_index=0,
                latex_pre=DEFAULT_LATEX_PRE, latex_post=DEFAULT_LATEX_POST):
     self.model_id = model_id
     self.name = name

--- a/genanki/model.py
+++ b/genanki/model.py
@@ -12,17 +12,17 @@ class Model:
                        + '\\begin{document}\n')
   DEFAULT_LATEX_POST = '\\end{document}'
 
-  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_index=0,
-               latex_pre=DEFAULT_LATEX_PRE, latex_post=DEFAULT_LATEX_POST):
+  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK,
+               latex_pre=DEFAULT_LATEX_PRE, latex_post=DEFAULT_LATEX_POST, sort_field_index=0):
     self.model_id = model_id
     self.name = name
     self.set_fields(fields)
     self.set_templates(templates)
     self.css = css
     self.model_type = model_type
-    self.sort_field_index = sort_field_index
     self.latex_pre = latex_pre
     self.latex_post = latex_post
+    self.sort_field_index = sort_field_index
 
   def set_fields(self, fields):
     if isinstance(fields, list):

--- a/genanki/model.py
+++ b/genanki/model.py
@@ -12,7 +12,7 @@ class Model:
                        + '\\begin{document}\n')
   DEFAULT_LATEX_POST = '\\end{document}'
 
-  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_number=1,
+  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_index=1,
                latex_pre=DEFAULT_LATEX_PRE, latex_post=DEFAULT_LATEX_POST):
     self.model_id = model_id
     self.name = name
@@ -20,7 +20,7 @@ class Model:
     self.set_templates(templates)
     self.css = css
     self.model_type = model_type
-    self.sort_field_id = sort_field_number-1
+    self.sort_field_index = sort_field_index
     self.latex_pre = latex_pre
     self.latex_post = latex_post
 
@@ -118,7 +118,7 @@ class Model:
       "mod": int(timestamp),
       "name": self.name,
       "req": self._req,
-      "sortf": self.sort_field_id,
+      "sortf": self.sort_field_index,
       "tags": [],
       "tmpls": self.templates,
       "type": self.model_type,

--- a/genanki/model.py
+++ b/genanki/model.py
@@ -12,7 +12,7 @@ class Model:
                        + '\\begin{document}\n')
   DEFAULT_LATEX_POST = '\\end{document}'
 
-  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK,
+  def __init__(self, model_id=None, name=None, fields=None, templates=None, css='', model_type=FRONT_BACK, sort_field_number=1,
                latex_pre=DEFAULT_LATEX_PRE, latex_post=DEFAULT_LATEX_POST):
     self.model_id = model_id
     self.name = name
@@ -20,6 +20,7 @@ class Model:
     self.set_templates(templates)
     self.css = css
     self.model_type = model_type
+    self.sort_field_id = sort_field_number-1
     self.latex_pre = latex_pre
     self.latex_post = latex_post
 
@@ -117,7 +118,7 @@ class Model:
       "mod": int(timestamp),
       "name": self.name,
       "req": self._req,
-      "sortf": 0,
+      "sortf": self.sort_field_id,
       "tags": [],
       "tmpls": self.templates,
       "type": self.model_type,

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -62,7 +62,7 @@ class Note:
 
   @property
   def sort_field(self):
-    return self._sort_field or self.fields[self.model.sort_field_id]
+    return self._sort_field or self.fields[self.model.sort_field_index]
 
   @sort_field.setter
   def sort_field(self, val):

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -62,7 +62,7 @@ class Note:
 
   @property
   def sort_field(self):
-    return self._sort_field or self.fields[0]
+    return self._sort_field or self.fields[self.model.sort_field_id]
 
   @sort_field.setter
   def sort_field(self, val):


### PR DESCRIPTION
It is now possible to define a `sort_field` value for notes by
setting a `sort_field_number` when creating the model.
When the `sort_field` argument is unused upon note creation, then
the field corresponding to the models `sort_field_number` will be
used. The default value is `1` (for first field).

The changes are compatible with previous versions.