### PR TITLE
Fixed the issue where cards couldn't be created if an anki option (like {{furigana:Word}}) was used in a partial in the qfmt field.

### DIFF
--- a/genanki/model.py
+++ b/genanki/model.py
@@ -43,7 +43,7 @@ class Model:
     sentinel = 'SeNtInEl'
     field_names = [field['name'] for field in self.fields]
 
-    partial_option_re = re.compile("{{.*:")
+    partial_option_re = re.compile(r"{{(?!cloze:)[\w]*(?<!}):")
 
     req = []
     for template_ord, template in enumerate(self.templates):


### PR DESCRIPTION
I discovered that I couldn't generate any cards if I used either {{kanji:Word}} or {{furigana:Word}} in the qfmt field of a template. 

I deducted that "pystache.render(....)" wasn't able to render the sentinal value into the template because of the prepended option.

I cleaned out the option using a regex subtitution and tested this implementation successfully in my own project.