### PR TITLE
Feature Deck Configurations

### DIFF
--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -6,5 +6,6 @@ from .deck import Deck
 from .model import Model
 from .note import Note
 from .package import Package
+from .deck_conf import DeckConf
 
 from .util import guid_for

--- a/genanki/deck.py
+++ b/genanki/deck.py
@@ -1,10 +1,11 @@
 import json
 
 class Deck:
-  def __init__(self, deck_id=None, name=None, description=''):
+  def __init__(self, deck_id=None, name=None, description='', conf=None):
     self.deck_id = deck_id
     self.name = name
     self.description = description
+    self.conf = conf
     self.notes = []
     self.models = {}  # map of model id to model
 
@@ -15,9 +16,10 @@ class Deck:
     self.models[model.model_id] = model
 
   def to_json(self):
+    conf = 1 if self.conf is None else self.conf.deck_conf_id
     return {
       "collapsed": False,
-      "conf": 1,
+      "conf": conf,
       "desc": self.description,
       "dyn": 0,
       "extendNew": 0,
@@ -54,6 +56,9 @@ class Deck:
     decks = json.loads(decks_json_str)
     decks.update({str(self.deck_id): self.to_json()})
     cursor.execute('UPDATE col SET decks = ?', (json.dumps(decks),))
+
+    if self.conf is not None:
+      self.conf.write_to_db(cursor, now_ts)
 
     models_json_str, = cursor.execute('SELECT models from col').fetchone()
     models = json.loads(models_json_str)

--- a/genanki/deck_conf.py
+++ b/genanki/deck_conf.py
@@ -1,0 +1,68 @@
+
+import json
+
+
+DEFAULT_CONF = {
+    "autoplay": True,
+    "id": 1,
+    "lapse": {
+        "delays": [
+            10
+        ],
+        "leechAction": 0,
+        "leechFails": 8,
+        "minInt": 1,
+        "mult": 0
+    },
+    "maxTaken": 60,
+    "mod": 0,
+    "name": "Default",
+    "new": {
+        "bury": True,
+        "delays": [
+            1,
+            10
+        ],
+        "initialFactor": 2500,
+        "ints": [
+            1,
+            4,
+            7
+        ],
+        "order": 1,
+        "perDay": 20,
+        "separate": True
+    },
+    "replayq": True,
+    "rev": {
+        "bury": True,
+        "ease4": 1.3,
+        "fuzz": 0.05,
+        "ivlFct": 1,
+        "maxIvl": 36500,
+        "minSpace": 1,
+        "perDay": 100
+    },
+    "timer": 0,
+    "usn": 0
+}
+
+
+class DeckConf:
+  def __init__(self, deck_conf_id, name, conf=None):
+    self.deck_conf_id = deck_conf_id
+    self.name = name
+    conf = DEFAULT_CONF.copy() if conf is None else conf
+    conf["name"] = self.name
+    conf["id"] = self.deck_conf_id
+    self.conf = conf
+
+  def to_json(self):
+    return self.conf
+
+  def write_to_db(self, cursor, now_ts):
+    conf_json_str, = cursor.execute('SELECT dconf FROM col').fetchone()
+    confs = json.loads(conf_json_str)
+    confs.update({str(self.deck_conf_id): self.to_json()})
+    cursor.execute('UPDATE col SET dconf = ?', (json.dumps(confs),))
+

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -306,3 +306,22 @@ class TestWithCollection:
     imported_deck = all_decks[1]
 
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
+
+  def test_deck_with_config(self):
+    conf = genanki.DeckConf(666, 'MyConf')
+    # Changing default initialFactor from 2500 to 4500
+    conf.conf['new']['initialFactor'] = 4500
+    deck = genanki.Deck(112233, 'foodeck', conf=conf)
+    # The Anki importer need at least one card to import the config.
+    # See related discussion:
+    # https://anki.tenderapp.com/discussions/ankidesktop/38114-importing-apkg-does-not-update-deck-config-fields
+    note = genanki.Note(TEST_MODEL, ['a', 'b'])
+    deck.add_note(note)
+
+    self.import_package(genanki.Package(deck))
+
+    all_confs = self.col.decks.allConf()
+    assert len(all_confs) == 2  # default conf and MyConf
+    imported_deck = all_confs[1]
+
+    assert imported_deck['new']['initialFactor'] == 4500


### PR DESCRIPTION
Adding support for deck configurations.
Now there is a new class called `DeckConf` that contains a dictionary with the deck configuration (with exactly the same nomenclature as used in the Anki database).
The `Deck` class now has a new parameter called `conf` that expects a `DeckConf` object.

Notes:
 * If we reuse the same configuration in several decks, we are really doing 2 updates in the database when one would be enough.
 * For the configuration to be imported there must be at least one new card in the collection. This is a limitation of the Anki library, not of the apkgs generator. More details:
https://anki.tenderapp.com/discussions/ankidesktop/38114-importing-apkg-does-not-update-deck-config-fields