### PR TITLE
Add check that number of fields in model and note match

### DIFF
--- a/genanki/note.py
+++ b/genanki/note.py
@@ -47,6 +47,8 @@ class _TagList(list):
 
 class Note:
   def __init__(self, model=None, fields=None, sort_field=None, tags=None, guid=None):
+    self._model = None
+    self._fields = None
     self.model = model
     self.fields = fields
     self.sort_field = sort_field
@@ -56,6 +58,29 @@ class Note:
     except AttributeError:
       # guid was defined as a property
       pass
+
+  @property
+  def model(self):
+    return self._model
+
+  @model.setter
+  def model(self, val):
+    self._model = val
+    self._check_number_model_fields_matches_num_fields()
+
+  @property
+  def fields(self):
+    return self._fields
+
+  @fields.setter
+  def fields(self, val):
+    self._fields = val
+    self._check_number_model_fields_matches_num_fields()
+
+  def _check_number_model_fields_matches_num_fields(self):
+    if self.model is not None and self.fields is not None:
+      if len(self.model.fields) != len(self.fields):
+        raise ValueError('Number of fields in Model does not match number of fields in Note')
 
   @property
   def sort_field(self):
@@ -120,6 +145,7 @@ class Note:
     self._guid = val
 
   def write_to_db(self, cursor, now_ts, deck_id):
+    self._check_number_model_fields_matches_num_fields()
     cursor.execute('INSERT INTO notes VALUES(null,?,?,?,?,?,?,?,?,?,?);', (
         self.guid,                    # guid
         self.model.model_id,          # mid

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -43,3 +43,71 @@ class TestTags:
     n.tags.insert(0, 'lucina')
     with pytest.raises(ValueError):
       n.tags.insert(0, 'nerf joker pls')
+
+
+def test_num_fields_equals_model_ok():
+  m = genanki.Model(
+    1894808898,
+    'Test Model',
+    fields=[
+      {'name': 'Question'},
+      {'name': 'Answer'},
+      {'name': 'Extra'},
+    ],
+    templates=[
+      {
+        'name': 'Card 1',
+        'qfmt': '{{Question}}',
+        'afmt': '{{FrontSide}}<hr id="answer">{{Answer}}',
+      },
+    ])
+
+  n = genanki.Note(
+    model=m,
+    fields=['What is the capital of Taiwan?', 'Taipei',
+            'Taipei was originally inhabitied by the Ketagalan people prior to the arrival of Han settlers in 1709.'])
+  # test passes if code gets to here without raising
+
+
+def test_num_fields_less_than_model_raises():
+  m = genanki.Model(
+    1894808898,
+    'Test Model',
+    fields=[
+      {'name': 'Question'},
+      {'name': 'Answer'},
+      {'name': 'Extra'},
+    ],
+    templates=[
+      {
+        'name': 'Card 1',
+        'qfmt': '{{Question}}',
+        'afmt': '{{FrontSide}}<hr id="answer">{{Answer}}',
+      },
+    ])
+
+  with pytest.raises(ValueError):
+    n = genanki.Note(model=m, fields=['What is the capital of Taiwan?', 'Taipei'])
+
+
+def test_num_fields_less_than_model_raises():
+  m = genanki.Model(
+    1894808898,
+    'Test Model',
+    fields=[
+      {'name': 'Question'},
+      {'name': 'Answer'},
+    ],
+    templates=[
+      {
+        'name': 'Card 1',
+        'qfmt': '{{Question}}',
+        'afmt': '{{FrontSide}}<hr id="answer">{{Answer}}',
+      },
+    ])
+
+  with pytest.raises(ValueError):
+    n = genanki.Note(
+      model=m,
+      fields=['What is the capital of Taiwan?', 'Taipei',
+              'Taipei was originally inhabitied by the Ketagalan people prior to the arrival of Han settlers in 1709.'])


### PR DESCRIPTION
Add a helper method to check that the number of fields in a Note matches the number of fields in its corresponding Model, and call it whenever we update .model or .fields on a Note, or when we call .write_to_db().
    
Helps with https://github.com/kerrickstaley/genanki/issues/50
