### PR TITLE
Get pkg as bytes

### DIFF
--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -305,4 +305,27 @@ class TestWithCollection:
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
 
 
-  
+  def test_multi_deck_package_as_bytes(self):
+      deck1 = genanki.Deck(123456, 'foodeck')
+      deck2 = genanki.Deck(654321, 'bardeck')
+
+      note = genanki.Note(TEST_MODEL, ['a', 'b'])
+
+      deck1.add_note(note)
+      deck2.add_note(note)
+
+      pkg = genanki.Package([deck1, deck2]).get_pkg_as_bytes()
+
+      #test writing bytes to disk to make sure still readable as valid anki package
+      test_pkg = "test.apkg"
+      with open(test_pkg, 'wb') as f:
+        f.write(pkg.getbuffer())
+
+      importer = anki.importing.apkg.AnkiPackageImporter(self.col, test_pkg)
+      importer.run()
+
+      #cleanup file
+      os.remove(test_pkg)
+
+      all_imported_decks = self.col.decks.all()
+      assert len(all_imported_decks) == 3  # default deck, foodeck, and bardeck

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -122,7 +122,6 @@ class TestWithCollection:
     all_imported_decks = self.col.decks.all()
     assert len(all_imported_decks) == 2  # default deck and foodeck
     imported_deck = all_imported_decks[1]
-
     assert imported_deck['name'] == 'foodeck'
 
   def test_generated_deck_has_valid_cards(self):
@@ -233,8 +232,8 @@ class TestWithCollection:
     os.remove('present.mp3')
     os.remove('present.jpg')
 
-    missing, unused, invalid = self.check_media()
-    assert set(missing) == {'missing.mp3', 'missing.jpg'}
+    ret = self.check_media()
+    assert set(ret.missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_media_files_absolute_paths(self):
     # change to a scratch directory so we can write files
@@ -256,9 +255,8 @@ class TestWithCollection:
       h.write(VALID_JPG)
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
-
-    missing, unused, invalid = self.check_media()
-    assert set(missing) == {'missing.mp3', 'missing.jpg'}
+    ret = self.check_media()
+    assert set(ret.missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_write_deck_without_deck_id_fails(self):
     # change to a scratch directory so we can write files
@@ -304,5 +302,7 @@ class TestWithCollection:
     all_decks = self.col.decks.all()
     assert len(all_decks) == 2  # default deck and foodeck
     imported_deck = all_decks[1]
-
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
+
+
+  

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -122,6 +122,7 @@ class TestWithCollection:
     all_imported_decks = self.col.decks.all()
     assert len(all_imported_decks) == 2  # default deck and foodeck
     imported_deck = all_imported_decks[1]
+    
     assert imported_deck['name'] == 'foodeck'
 
   def test_generated_deck_has_valid_cards(self):
@@ -255,6 +256,7 @@ class TestWithCollection:
       h.write(VALID_JPG)
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
+    
     missing, unused, invalid = self.check_media()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
@@ -302,6 +304,7 @@ class TestWithCollection:
     all_decks = self.col.decks.all()
     assert len(all_decks) == 2  # default deck and foodeck
     imported_deck = all_decks[1]
+    
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
 
 

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -232,8 +232,8 @@ class TestWithCollection:
     os.remove('present.mp3')
     os.remove('present.jpg')
 
-    ret = self.check_media()
-    assert set(ret.missing) == {'missing.mp3', 'missing.jpg'}
+    missing, unused, invalid = self.check_media()
+    assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_media_files_absolute_paths(self):
     # change to a scratch directory so we can write files
@@ -255,8 +255,8 @@ class TestWithCollection:
       h.write(VALID_JPG)
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
-    ret = self.check_media()
-    assert set(ret.missing) == {'missing.mp3', 'missing.jpg'}
+    missing, unused, invalid = self.check_media()
+    assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
   def test_write_deck_without_deck_id_fails(self):
     # change to a scratch directory so we can write files

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -122,7 +122,7 @@ class TestWithCollection:
     all_imported_decks = self.col.decks.all()
     assert len(all_imported_decks) == 2  # default deck and foodeck
     imported_deck = all_imported_decks[1]
-    
+ 
     assert imported_deck['name'] == 'foodeck'
 
   def test_generated_deck_has_valid_cards(self):
@@ -256,7 +256,7 @@ class TestWithCollection:
       h.write(VALID_JPG)
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
-    
+ 
     missing, unused, invalid = self.check_media()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
@@ -304,9 +304,8 @@ class TestWithCollection:
     all_decks = self.col.decks.all()
     assert len(all_decks) == 2  # default deck and foodeck
     imported_deck = all_decks[1]
-    
+ 
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
-
 
   def test_multi_deck_package_as_bytes(self):
       deck1 = genanki.Deck(123456, 'foodeck')

--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -122,7 +122,7 @@ class TestWithCollection:
     all_imported_decks = self.col.decks.all()
     assert len(all_imported_decks) == 2  # default deck and foodeck
     imported_deck = all_imported_decks[1]
- 
+
     assert imported_deck['name'] == 'foodeck'
 
   def test_generated_deck_has_valid_cards(self):
@@ -256,7 +256,7 @@ class TestWithCollection:
       h.write(VALID_JPG)
 
     self.import_package(genanki.Package(deck, media_files=[present_mp3_path, present_jpg_path]))
- 
+
     missing, unused, invalid = self.check_media()
     assert set(missing) == {'missing.mp3', 'missing.jpg'}
 
@@ -304,7 +304,7 @@ class TestWithCollection:
     all_decks = self.col.decks.all()
     assert len(all_decks) == 2  # default deck and foodeck
     imported_deck = all_decks[1]
- 
+
     assert imported_deck['desc'] == 'This is my great deck.\nIt is so so great.'
 
   def test_multi_deck_package_as_bytes(self):


### PR DESCRIPTION
Added method to get package as bytes object. I used this to build a package on a server and send to client over HTTP for download. Includes unit test that verifies bytes package is still a valid anki package.