### PR TITLE
set due field for cards to position of the coresponding note inside the deck

### DIFF
--- a/genanki/card.py
+++ b/genanki/card.py
@@ -3,7 +3,7 @@ class Card:
     self.ord = ord
     self.suspend = suspend
 
-  def write_to_db(self, cursor, timestamp: float, deck_id, note_id, id_gen):
+  def write_to_db(self, cursor, timestamp: float, deck_id, note_id, id_gen, note_index):
     queue = -1 if self.suspend else 0
     cursor.execute('INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
         next(id_gen),    # id
@@ -14,7 +14,7 @@ class Card:
         -1,              # usn
         0,               # type (=0 for non-Cloze)
         queue,           # queue
-        0,               # due
+        note_index,      # due
         0,               # ivl
         0,               # factor
         0,               # reps

--- a/genanki/card.py
+++ b/genanki/card.py
@@ -3,7 +3,7 @@ class Card:
     self.ord = ord
     self.suspend = suspend
 
-  def write_to_db(self, cursor, timestamp: float, deck_id, note_id, id_gen, note_index):
+  def write_to_db(self, cursor, timestamp: float, deck_id, note_id, id_gen, note_index=0):
     queue = -1 if self.suspend else 0
     cursor.execute('INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);', (
         next(id_gen),    # id

--- a/genanki/deck.py
+++ b/genanki/deck.py
@@ -63,8 +63,8 @@ class Deck:
       {model.model_id: model.to_json(timestamp, self.deck_id) for model in self.models.values()})
     cursor.execute('UPDATE col SET models = ?', (json.dumps(models),))
 
-    for note in self.notes:
-      note.write_to_db(cursor, timestamp, self.deck_id, id_gen)
+    for i,note in enumerate(self.notes):
+      note.write_to_db(cursor, timestamp, self.deck_id, id_gen, i)
 
   def write_to_file(self, file):
     """

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -146,7 +146,7 @@ class Note:
         warnings.warn("Field contained the following invalid HTML tags. Make sure you are calling html.escape() if"
                       " your field data isn't already HTML-encoded: {}".format(' '.join(invalid_tags)))
 
-  def write_to_db(self, cursor, timestamp: float, deck_id, id_gen):
+  def write_to_db(self, cursor, timestamp: float, deck_id, id_gen, note_index):
     self._check_number_model_fields_matches_num_fields()
     self._check_invalid_html_tags_in_fields()
     cursor.execute('INSERT INTO notes VALUES(?,?,?,?,?,?,?,?,?,?,?);', (
@@ -165,7 +165,7 @@ class Note:
 
     note_id = cursor.lastrowid
     for card in self.cards:
-      card.write_to_db(cursor, timestamp, deck_id, note_id, id_gen)
+      card.write_to_db(cursor, timestamp, deck_id, note_id, id_gen, note_index)
 
   def _format_fields(self):
     return '\x1f'.join(self.fields)

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -146,7 +146,7 @@ class Note:
         warnings.warn("Field contained the following invalid HTML tags. Make sure you are calling html.escape() if"
                       " your field data isn't already HTML-encoded: {}".format(' '.join(invalid_tags)))
 
-  def write_to_db(self, cursor, timestamp: float, deck_id, id_gen, note_index):
+  def write_to_db(self, cursor, timestamp: float, deck_id, id_gen, note_index=0):
     self._check_number_model_fields_matches_num_fields()
     self._check_invalid_html_tags_in_fields()
     cursor.execute('INSERT INTO notes VALUES(?,?,?,?,?,?,?,?,?,?,?);', (


### PR DESCRIPTION
when using more then 1 template the order of new cards currently is the following:
note 1 template 1
note 2 template 1
note 3 template 1
note 1 template 2
note 2 template 2
note 3 template 2

this is probably not what most people want. 
E.g. when creating decks for language learning you usually have 2 templates (one for "eng->other language" and one for "other language->eng") and the card with the second template should appear right after the first.

this fix changes the order to:
note 1 template 1
note 1 template 2
note 2 template 1
note 2 template 2
note 3 template 1
note 3 template 2

the behavior for decks with just 1 template remains unchanged
