### PR TITLE
include LICENSE.txt in source distributions, specify minimum python

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(name='genanki',
       license='MIT',
       packages=['genanki'],
       zip_safe=False,
+      include_package_data=True,
+      python_requires='>=3.6',
       install_requires=[
         'cached-property',
         'frozendict',


### PR DESCRIPTION
Hello, thanks for this tool!

I'm looking to build this for [conda-forge](https://github.com/conda-forge/staged-recipes), and as such it's usually nice to have the authoritative license file included in the distribution... even though it's not _strictly_ required by the MIT license.

This PR adds a `MANIFEST.in` including the license, and tweaks the `setup.py` metadata a hair to include it and make the python requirement more explicit. No worries if you don't wish to make these changes, feel free to close, as I can just pull the license from the repo... though it would _also_ be helpful to have git tags that coincide with the actual release versions for this purpose (just in case you _do_ decide to change it).

Thanks again!