### PR TITLE
Add support for uppercase characters in HTML tags

### DIFF
--- a/genanki/note.py
+++ b/genanki/note.py
@@ -47,7 +47,7 @@ class _TagList(list):
 
 
 class Note:
-  _INVALID_HTML_TAG_RE = re.compile(r'<(?!/?[a-z0-9]+(?: .*|/?)>)(?:.|\n)*?>')
+  _INVALID_HTML_TAG_RE = re.compile(r'<(?!/?[a-zA-Z0-9]+(?: .*|/?)>)(?:.|\n)*?>')
 
   def __init__(self, model=None, fields=None, sort_field=None, tags=None, guid=None, due=0):
     self.model = model

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -172,6 +172,9 @@ class TestFindInvalidHtmlTagsInField:
 
   def test_ok_attrs(self):
     assert genanki.Note._find_invalid_html_tags_in_field('<h1 style="color: red">STOP</h1>') == []
+    
+  def test_ok_uppercase(self):
+    assert genanki.Note._find_invalid_html_tags_in_field('<TD></Td>') == []
 
   def test_ng_empty(self):
     assert genanki.Note._find_invalid_html_tags_in_field(' hello <> goodbye') == ['<>']


### PR DESCRIPTION
Fixes #88 

We could also use `_INVALID_HTML_TAG_RE = re.compile(r'<(?!/?[a-z0-9]+(?: .*|/?)>)(?:.|\n)*?>', re.IGNORECASE | re.ASCII)` instead of adding `A-Z` in the pattern, let me know what you prefer.