### PR TITLE
Replace pystache with chevron

### DIFF
--- a/genanki/model.py
+++ b/genanki/model.py
@@ -1,6 +1,6 @@
 from copy import copy
 from cached_property import cached_property
-import pystache
+import chevron
 import yaml
 
 class Model:
@@ -41,7 +41,7 @@ class Model:
     """
     List of required fields for each template. Format is [tmpl_idx, "all"|"any", [req_field_1, req_field_2, ...]].
 
-    Partial reimplementation of req computing logic from Anki. We use pystache instead of Anki's custom mustache
+    Partial reimplementation of req computing logic from Anki. We use chevron instead of Anki's custom mustache
     implementation.
 
     The goal is to figure out which fields are "required", i.e. if they are missing then the front side of the note
@@ -57,7 +57,7 @@ class Model:
         field_values = {field: sentinel for field in field_names}
         field_values[field] = ''
 
-        rendered = pystache.render(template['qfmt'], field_values)
+        rendered = chevron.render(template['qfmt'], field_values)
 
         if sentinel not in rendered:
           # when this field is missing, there is no meaningful content (no field values) in the question, so this field
@@ -73,7 +73,7 @@ class Model:
         field_values = {field: '' for field in field_names}
         field_values[field] = sentinel
 
-        rendered = pystache.render(template['qfmt'], field_values)
+        rendered = chevron.render(template['qfmt'], field_values)
 
         if sentinel in rendered:
           # when this field is present, there is meaningful content in the question

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='genanki',
       install_requires=[
         'cached-property',
         'frozendict',
-        'pystache',
+        'chevron',
         'pyyaml',
       ],
       setup_requires=[


### PR DESCRIPTION
pystache has been unmaintained for a long time, with the [last commit]
to [defunkt/pystache] being from September 2014. By now it is not
installable with up-to-date setuptools.
Luckily, genanki uses only the most basic of mustache API, and [chevron]
fills the gap nicely. Tests are passing for me again.

[chevron]: https://github.com/noahmorrison/chevron
[defunkt/pystache]: https://github.com/defunkt/pystache
[last commit]:
https://github.com/defunkt/pystache/commit/17a5dfdcd56eb76af731d141de395a7632a905b8