### PR TITLE
Add "Back Extra" field to Cloze builtin model

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ for fields.
 may work but has not been tested). See the [`.write_to_collection_from_addon() method`](
 https://github.com/kerrickstaley/genanki/blob/0c2cf8fea9c5e382e2fae9cd6d5eb440e267c637/genanki/__init__.py#L275).
 
+## CLOZE_MODEL DeprecationWarning
+Due to a mistake, in genanki versions before 0.13.0, `builtin_models.CLOZE_MODEL` only had a single field, whereas the real Cloze model that is built into Anki has two fields. If you get a `DeprecationWarning` when using `CLOZE_MODEL`, simply add another field (it can be an empty string) when creating your `Note`, e.g.
+
+```python
+my_note = genanki.Note(
+  model=genanki.CLOZE_MODEL,
+  fields=['{{c1::Rome}} is the capital of {{c2::Italy}}', ''])
+```
+
 ## FAQ
 ### My field data is getting garbled
 If fields in your notes contain literal `<`, `>`, or `&` characters, you need to HTML-encode them: field data is HTML, not plain text. You can use the [`html.escape`](https://docs.python.org/3/library/html.html#html.escape) function.

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -14,4 +14,3 @@ from .builtin_models import BASIC_AND_REVERSED_CARD_MODEL
 from .builtin_models import BASIC_OPTIONAL_REVERSED_CARD_MODEL
 from .builtin_models import BASIC_TYPE_IN_THE_ANSWER_MODEL
 from .builtin_models import CLOZE_MODEL
-from .builtin_models import CLOZE_WITH_EXTRA_MODEL

--- a/genanki/__init__.py
+++ b/genanki/__init__.py
@@ -14,3 +14,4 @@ from .builtin_models import BASIC_AND_REVERSED_CARD_MODEL
 from .builtin_models import BASIC_OPTIONAL_REVERSED_CARD_MODEL
 from .builtin_models import BASIC_TYPE_IN_THE_ANSWER_MODEL
 from .builtin_models import CLOZE_MODEL
+from .builtin_models import CLOZE_WITH_EXTRA_MODEL

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -150,9 +150,10 @@ def _fix_deprecated_builtin_models_and_warn(model, fields):
   if model is CLOZE_MODEL and len(fields) == 1:
     fixed_fields = fields + ['']
     warnings.warn(
-      'Using CLOZE_MODEL with a single field is deprecated and may not work in the future.'
+      'Using CLOZE_MODEL with a single field is deprecated.'
       + ' Please pass two fields, e.g. {} .'.format(repr(fixed_fields))
-      + ' See TODO insert link', DeprecationWarning)
+      + ' See https://github.com/kerrickstaley/genanki#cloze_model-deprecationwarning .',
+      DeprecationWarning)
     return fixed_fields
 
   return fields

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -10,6 +10,8 @@ Note: Anki does not assign consistent IDs to its built-in models (see
     etc., which is less confusing.
 """
 
+import warnings
+
 from .model import Model
 
 
@@ -119,7 +121,7 @@ BASIC_TYPE_IN_THE_ANSWER_MODEL = Model(
   css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n',
 )
 
-_CLOZE_MODEL_WITHOUT_EXTRA = Model(
+_CLOZE_WITHOUT_EXTRA_MODEL = Model(
   1122529321,
   'Cloze (genanki)',
   model_type=Model.CLOZE,
@@ -140,7 +142,7 @@ _CLOZE_MODEL_WITHOUT_EXTRA = Model(
       '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
 )
 
-CLOZE_MODEL_WITH_EXTRA = Model(
+CLOZE_WITH_EXTRA_MODEL = Model(
   1550428389,
   'Cloze (genanki)',
   model_type=Model.CLOZE,
@@ -165,4 +167,8 @@ CLOZE_MODEL_WITH_EXTRA = Model(
       '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
 )
 
-CLOZE_MODEL = _CLOZE_MODEL_WITHOUT_EXTRA
+CLOZE_MODEL = _CLOZE_WITHOUT_EXTRA_MODEL
+
+def _warn_for_deprecated_builtin_model(model):
+  if model is _CLOZE_WITHOUT_EXTRA_MODEL:
+    warnings.warn('CLOZE_MODEL is deprecated; please use CLOZE_MODEL_WITH_EXTRA', DeprecationWarning)

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -121,28 +121,7 @@ BASIC_TYPE_IN_THE_ANSWER_MODEL = Model(
   css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n',
 )
 
-_CLOZE_WITHOUT_EXTRA_MODEL = Model(
-  1122529321,
-  'Cloze (genanki)',
-  model_type=Model.CLOZE,
-  fields=[
-    {
-      'name': 'Text',
-      'font': 'Arial',
-    },
-  ],
-  templates=[
-    {
-      'name': 'Cloze',
-      'qfmt': '{{cloze:Text}}',
-      'afmt': '{{cloze:Text}}',
-    },
-  ],
-  css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n\n'
-      '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
-)
-
-CLOZE_WITH_EXTRA_MODEL = Model(
+CLOZE_MODEL = Model(
   1550428389,
   'Cloze (genanki)',
   model_type=Model.CLOZE,
@@ -166,12 +145,6 @@ CLOZE_WITH_EXTRA_MODEL = Model(
   css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n\n'
       '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
 )
-
-CLOZE_MODEL = CLOZE_WITH_EXTRA_MODEL
-
-def _warn_for_deprecated_builtin_model(model):
-  if model is _CLOZE_WITHOUT_EXTRA_MODEL:
-    warnings.warn('CLOZE_MODEL is deprecated; please use CLOZE_MODEL_WITH_EXTRA', DeprecationWarning)
 
 def _fix_deprecated_builtin_models_and_warn(model, fields):
   if model is CLOZE_MODEL and len(fields) == 1:

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -150,7 +150,7 @@ def _fix_deprecated_builtin_models_and_warn(model, fields):
   if model is CLOZE_MODEL and len(fields) == 1:
     fixed_fields = fields + ['']
     warnings.warn(
-      'Using CLOZE_MODEL with a single field is deprecated and will not work in the future.'
+      'Using CLOZE_MODEL with a single field is deprecated and may not work in the future.'
       + ' Please pass two fields, e.g. {} .'.format(repr(fixed_fields))
       + ' See TODO insert link', DeprecationWarning)
     return fixed_fields

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -167,8 +167,19 @@ CLOZE_WITH_EXTRA_MODEL = Model(
       '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
 )
 
-CLOZE_MODEL = _CLOZE_WITHOUT_EXTRA_MODEL
+CLOZE_MODEL = CLOZE_WITH_EXTRA_MODEL
 
 def _warn_for_deprecated_builtin_model(model):
   if model is _CLOZE_WITHOUT_EXTRA_MODEL:
     warnings.warn('CLOZE_MODEL is deprecated; please use CLOZE_MODEL_WITH_EXTRA', DeprecationWarning)
+
+def _fix_deprecated_builtin_models_and_warn(model, fields):
+  if model is CLOZE_MODEL and len(fields) == 1:
+    fixed_fields = fields + ['']
+    warnings.warn(
+      'Using CLOZE_MODEL with a single field is deprecated and will not work in the future.'
+      + ' Please pass two fields, e.g. {} .'.format(repr(fixed_fields))
+      + ' See TODO insert link', DeprecationWarning)
+    return fixed_fields
+
+  return fields

--- a/genanki/builtin_models.py
+++ b/genanki/builtin_models.py
@@ -119,7 +119,7 @@ BASIC_TYPE_IN_THE_ANSWER_MODEL = Model(
   css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n',
 )
 
-CLOZE_MODEL = Model(
+_CLOZE_MODEL_WITHOUT_EXTRA = Model(
   1122529321,
   'Cloze (genanki)',
   model_type=Model.CLOZE,
@@ -139,3 +139,30 @@ CLOZE_MODEL = Model(
   css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n\n'
       '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
 )
+
+CLOZE_MODEL_WITH_EXTRA = Model(
+  1550428389,
+  'Cloze (genanki)',
+  model_type=Model.CLOZE,
+  fields=[
+    {
+      'name': 'Text',
+      'font': 'Arial',
+    },
+    {
+      'name': 'Back Extra',
+      'font': 'Arial',
+    },
+  ],
+  templates=[
+    {
+      'name': 'Cloze',
+      'qfmt': '{{cloze:Text}}',
+      'afmt': '{{cloze:Text}}<br>\n{{Back Extra}}',
+    },
+  ],
+  css='.card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n\n'
+      '.cloze {\n font-weight: bold;\n color: blue;\n}\n.nightMode .cloze {\n color: lightblue;\n}',
+)
+
+CLOZE_MODEL = _CLOZE_MODEL_WITHOUT_EXTRA

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -2,6 +2,7 @@ import re
 import warnings
 from cached_property import cached_property
 
+from .builtin_models import _warn_for_deprecated_builtin_model
 from .card import Card
 from .util import guid_for
 
@@ -60,6 +61,15 @@ class Note:
     except AttributeError:
       # guid was defined as a property
       pass
+
+  @property
+  def model(self):
+    return self._model
+
+  @model.setter
+  def model(self, val):
+    _warn_for_deprecated_builtin_model(val)
+    self._model = val
 
   @property
   def sort_field(self):

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -2,7 +2,6 @@ import re
 import warnings
 from cached_property import cached_property
 
-from .builtin_models import _warn_for_deprecated_builtin_model
 from .builtin_models import _fix_deprecated_builtin_models_and_warn
 from .card import Card
 from .util import guid_for
@@ -62,15 +61,6 @@ class Note:
     except AttributeError:
       # guid was defined as a property
       pass
-
-  @property
-  def model(self):
-    return self._model
-
-  @model.setter
-  def model(self, val):
-    _warn_for_deprecated_builtin_model(val)
-    self._model = val
 
   @property
   def sort_field(self):

--- a/genanki/note.py
+++ b/genanki/note.py
@@ -3,6 +3,7 @@ import warnings
 from cached_property import cached_property
 
 from .builtin_models import _warn_for_deprecated_builtin_model
+from .builtin_models import _fix_deprecated_builtin_models_and_warn
 from .card import Card
 from .util import guid_for
 
@@ -158,6 +159,7 @@ class Note:
                       " your field data isn't already HTML-encoded: {}".format(' '.join(invalid_tags)))
 
   def write_to_db(self, cursor, timestamp: float, deck_id, id_gen):
+    self.fields = _fix_deprecated_builtin_models_and_warn(self.model, self.fields)
     self._check_number_model_fields_matches_num_fields()
     self._check_invalid_html_tags_in_fields()
     cursor.execute('INSERT INTO notes VALUES(?,?,?,?,?,?,?,?,?,?,?);', (

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -1,8 +1,6 @@
 import genanki
 import os
-import pytest
 import tempfile
-import warnings
 
 
 def test_builtin_models():
@@ -26,20 +24,9 @@ def test_builtin_models():
     model=genanki.BASIC_TYPE_IN_THE_ANSWER_MODEL,
     fields=['Taiwan', 'Taipei']))
 
-  with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    my_deck.add_note(genanki.Note(
-      model=genanki.CLOZE_MODEL,
-      fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
-
-  with warnings.catch_warnings(record=True) as warning_list:
-    my_deck.add_note(genanki.Note(
-      model=genanki.CLOZE_WITH_EXTRA_MODEL,
-      fields=[
-        '{{c1::Ottawa}} is the capital of {{c2::Canada}}',
-        'Ottawa is in Ontario province.']))
-
-  assert not warning_list
+  my_deck.add_note(genanki.Note(
+    model=genanki.CLOZE_MODEL,
+    fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
 
   # Just try writing the note to a .apkg file; if there is no Exception, we assume things are good.
   fnode, fpath = tempfile.mkstemp()
@@ -47,9 +34,3 @@ def test_builtin_models():
   my_deck.write_to_file(fpath)
 
   os.unlink(fpath)
-
-def test_cloze_model_warns():
-  with pytest.warns(DeprecationWarning):
-    my_note = genanki.Note(
-      model=genanki.CLOZE_MODEL,
-      fields=['{{c1::Rome}} is the capital of {{c2::Italy}}'])

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -1,6 +1,8 @@
 import genanki
 import os
+import pytest
 import tempfile
+import warnings
 
 
 def test_builtin_models():
@@ -26,11 +28,35 @@ def test_builtin_models():
 
   my_deck.add_note(genanki.Note(
     model=genanki.CLOZE_MODEL,
-    fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
+    fields=[
+      '{{c1::Ottawa}} is the capital of {{c2::Canada}}',
+      'Ottawa is in Ontario province.']))
 
-  # Just try writing the note to a .apkg file; if there is no Exception, we assume things are good.
+  # Just try writing the notes to a .apkg file; if there is no Exception and no Warnings, we assume
+  # things are good.
   fnode, fpath = tempfile.mkstemp()
   os.close(fnode)
-  my_deck.write_to_file(fpath)
+
+  with warnings.catch_warnings(record=True) as warning_list:
+    my_deck.write_to_file(fpath)
+
+  assert not warning_list
+
+  os.unlink(fpath)
+
+def test_cloze_with_single_field_warns():
+  my_deck = genanki.Deck(
+    1598559905,
+    'Country Capitals')
+
+  my_deck.add_note(genanki.Note(
+    model=genanki.CLOZE_MODEL,
+    fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
+
+  fnode, fpath = tempfile.mkstemp()
+  os.close(fnode)
+
+  with pytest.warns(DeprecationWarning):
+    my_deck.write_to_file(fpath)
 
   os.unlink(fpath)

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -1,6 +1,8 @@
 import genanki
 import os
+import pytest
 import tempfile
+import warnings
 
 
 def test_builtin_models():
@@ -24,9 +26,20 @@ def test_builtin_models():
     model=genanki.BASIC_TYPE_IN_THE_ANSWER_MODEL,
     fields=['Taiwan', 'Taipei']))
 
-  my_deck.add_note(genanki.Note(
-    model=genanki.CLOZE_MODEL,
-    fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
+  with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    my_deck.add_note(genanki.Note(
+      model=genanki.CLOZE_MODEL,
+      fields=['{{c1::Rome}} is the capital of {{c2::Italy}}']))
+
+  with warnings.catch_warnings(record=True) as warning_list:
+    my_deck.add_note(genanki.Note(
+      model=genanki.CLOZE_WITH_EXTRA_MODEL,
+      fields=[
+        '{{c1::Ottawa}} is the capital of {{c2::Canada}}',
+        'Ottawa is in Ontario province.']))
+
+  assert not warning_list
 
   # Just try writing the note to a .apkg file; if there is no Exception, we assume things are good.
   fnode, fpath = tempfile.mkstemp()
@@ -34,3 +47,9 @@ def test_builtin_models():
   my_deck.write_to_file(fpath)
 
   os.unlink(fpath)
+
+def test_cloze_model_warns():
+  with pytest.warns(DeprecationWarning):
+    my_note = genanki.Note(
+      model=genanki.CLOZE_MODEL,
+      fields=['{{c1::Rome}} is the capital of {{c2::Italy}}'])


### PR DESCRIPTION
Due to a mistake, the "Back Extra" field was omitted from `genanki.builtin_models.CLOZE_MODEL`. This field shows extra information on the back of the card.

Add this field to `CLOZE_MODEL`. Also, add some code that runs inside Note.write_to_db that checks if `.fields` has only one element and `.model` is `CLOZE_MODEL`, and if so, fixes `.fields` and emits a warning.

This change may cause minor backwards-incompatibility issues, because the ID of `CLOZE_MODEL` has changed. The only visible effect should be that a deck of Cloze notes created before this change and a similar deck created after this change will have different Note Types when both are imported into Anki. (Note Type is the Anki UI's term for what the source code calls Model).