### PR TITLE
#102 #103 Allow users to override write functionality more easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ You *cannot* put `<img src="{MyMedia}">` in the template and `image.jpg` in the 
 
 You should only put the filename (aka basename) and not the full path in the field; `<img src="images/image.jpg">` will *not* work. Media files should have unique filenames.
 
+  ### Custom Media functionality
+  if standard media handling doesn't suit your needs (i.e. your data is in a db or in memory and you want to directly write to zip instead of having to use intermediary file) then supply a `media_function(outzip, idx, path)` to package instantiation. use `outzip.writestr()` to write data, `path` as the target filepath when anki imports into its collection.media folder (must follow same uniqueness constraint mentioned above for standard functionality), `idx` is the path you MUST use to write to zip (this is anki requirement due to how it unpacks media)). 
+
+```python 
+from genanki import Package
+
+def media_function(outzip, idx, path): 
+  data = sqlite3.connect(DBPATH).execute('select data from table').fetchone()[0]
+  outzip.writestr(str(idx), data)
+
+Package(DECK, media_files=MEDIA_PATHS, media_function=media_function).write_to_file(PACKAGE_PATH)
+```
+
+
 ## Note GUIDs
 `Note`s have a `guid` property that uniquely identifies the note. If you import a new note that has the same GUID as an
 existing note, the new note will overwrite the old one (as long as their models have the same fields).


### PR DESCRIPTION
Referring to #102 and #103:

Allow users to just override the zip file write part instead of entire write function. 

Summary of changes:
 + ability to specify a media_function which if filled with a valid function can allow customizing to user needs. fallback is standard media write functionality.
 + context manager for sqlite because looks cleaner and autocommits on success. You can drop this part if not to your preference. 
 + instead of mkstemp why not use NamedTemporaryFile? I like it because it automatically closes the file upon cleanup due to exit or scope change. mkstemp needs to be manually cleaned and handled which can leave files if interrupted somehow. 
 + write package to temp file first, then on success move to final location. This way, an error won't delete an existing package that one may attempt to overwrite. Basically a safety step. This is also the same default behavior for linux zip command line utility. It first writes to temp file in same directory then moves to overwrite.