### PR TITLE
Include README.md in package metadata (fix #110)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
 from setuptools import setup
+from pathlib import Path
 
 version = {}
 with open('genanki/version.py') as fp:
   exec(fp.read(), version)
 
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(name='genanki',
       version=version['__version__'],
       description='Generate Anki decks programmatically',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       url='http://github.com/kerrickstaley/genanki',
       author='Kerrick Staley',
       author_email='k@kerrickstaley.com',


### PR DESCRIPTION
Uses the method described in the Python Packaging User Guide:

https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata

You can see the result here:
https://test.pypi.org/project/genanki-test-chambln/

Just upload with setup.py and twine as normal:

```sh
rm -rf dist/*
python3 setup.py sdist bdist_wheel
python3 -m twine upload dist/*
```

Or pass `--repository testpypi` to upload to test.pypi.org instead:

```sh
python3 -m twine upload --repository testpypi dist/*
```