### PR TITLE
Exclude Ubuntu + Python 3.6 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         python-version: [3.6, 3.8, 3.9]
         anki-version: [ed8340a4e3a2006d6285d7adf9b136c735ba2085]
         exclude:
+          # latest Ubuntu supports Python 3.7 and later
+          - os: ubuntu
+            python-version: 3.6
           # compatible pyaudio not available
           - os: windows
             python-version: 3.8


### PR DESCRIPTION
GitHub doesn't have a Python 3.6 package for the latest Ubuntu 22 image.