### PR TITLE
Assign card dues per individual card and not just note level

### DIFF
--- a/tests/test_genanki.py
+++ b/tests/test_genanki.py
@@ -521,7 +521,7 @@ class TestWithCollection:
     next_card = self.col.sched.getCard()
     next_note = self.col.getNote(next_card.nid)
 
-    # Next card changes to "Capital of Oregon", because it was created first.
+    # Next card is "Capital of Washington", because it was created first.
     assert next_note.fields == ['Capital of Washington', 'Olympia']
 
   def test_notes_with_card_and_note_due(self):


### PR DESCRIPTION
Hi! My use case in Anki has me generating more than 1 card for every note in a model. But I also want to make sure the user sees the cards from a specific template before they see any cards generated by the next template.

Currently, this is not possible to do in genanki, as card dues can only be assigned per individual note level. The workaround is to create duplicate notes for each card type, but that leads to lots of duplicate information and is quite clunky to work with.

I tried my best to figure out a way to implement this without murdering your backward compatibility, it's not the cleanest but it does work. If you spot a way to do this with a cleaner API surface I'm all for that.