### PR TITLE
Eliminate duplicate media files.

### DIFF
--- a/genanki/package.py
+++ b/genanki/package.py
@@ -19,7 +19,7 @@ class Package:
     else:
       self.decks = deck_or_decks
 
-    self.media_files = media_files or []
+    self.media_files = list(set(media_files or []))
 
   def write_to_file(self, file, timestamp: Optional[float] = None):
     """


### PR DESCRIPTION
This helps radically reduce the package size for users of the tool who don't do their own deduplication.

Anki does eventually eliminate duplicates, but this ensures that the package size is minimized during transmission as well.

The fact that Anki is so good at optimizing the package sizes perhaps leads some users to not worry about deduplication while they generate the packages.

Use of duplicate media files has been observed in several users who complained about their generated package being larger than they expect given their media or given the final package size when uploaded to Anki.