### PR TITLE
Add support for opendoas & void-linux to setup_tests script

### DIFF
--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -3,9 +3,33 @@
 set -e
 anki_test_revision=ed8340a4e3a2006d6285d7adf9b136c735ba2085
 
+# Checks if the first argument is a valid executable in a POSIX-compatible way
+command_exists() {
+    command -v "$1" >/dev/null
+}
+
+# fallback to doas if sudo is not installed
+if command_exists sudo; then
+    elevator="sudo"
+elif command_exists doas; then
+    elevator="doas"
+else
+    echo "error: neither sudo nor doas is installed" 1>&2
+    exit 1
+fi
+
 # install pyaudio system deps
-sudo apt-get -y update && sudo apt-get install -y python-all-dev portaudio19-dev ripgrep moreutils \
-|| sudo pacman -S --noconfirm --needed portaudio python-virtualenv ripgrep moreutils
+if command_exists apt-get; then
+    $elevator apt-get -y update
+    $elevator apt-get install -y python-all-dev portaudio19-dev ripgrep moreutils
+elif command_exists pacman; then
+    $elevator pacman -S pacman -S --noconfirm --needed portaudio python-virtualenv ripgrep moreutils
+elif command_exists xbps-install; then
+    $elevator xbps-install --sync --yes portaudio python3-virtualenv ripgrep moreutils
+else
+    echo "error: couldn't find a suitable package manager"
+    exit 1
+fi
 
 # enter venv if needed
 if [[ -z "$VIRTUAL_ENV" ]]; then


### PR DESCRIPTION
Some systems (like mine) do not have `sudo` installed, but use the `opendoas` package to perform the same function.

The Void Linux package manager (xbps) was fairly easy to implement support for, though I restructured that part of code to do it.

I can think of one issue, but it was already present in the script in the first place: it's perfectly possible to have package managers from other distributions on your system, for managing chroot-like things. Maybe better OS detection or something more OS-independent would be better in the longterm.