### PR TITLE
Fix comparison between set and dictionary

### DIFF
--- a/genanki/note.py
+++ b/genanki/note.py
@@ -101,7 +101,7 @@ class Note:
       field_value = self.fields[field_index] if field_index >= 0 else ""
       # update card_ords with each cloze reference N, e.g. "{{cN::...}}"
       card_ords.update(int(m)-1 for m in re.findall(r"{{c(\d+)::.+?}}", field_value, re.DOTALL) if int(m) > 0)
-    if card_ords == {}:
+    if not card_ords:
       card_ords = {0}
     return([Card(ord) for ord in card_ords])
 


### PR DESCRIPTION
The check `card_ords == {}` will always evaluate to `False`, even when it is empty. This is because `card_ords` is a set, and `{}` is a dictionary.

```python
>>> set() == {}
False
```

The intended check was probably something like "card ords is empty", which can be expressed as `if not card_ords`.